### PR TITLE
cicd: limit by repo owner

### DIFF
--- a/.github/workflows/add-action-project.yml
+++ b/.github/workflows/add-action-project.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   add-to-project:
+    if: github.repository_owner == 'cowprotocol'
     name: Add issue to project
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR:

1. Limits the add-to-project action to only run when the repository owner is `cowprotocol`. This helps when users clone downstream repos and prevents CI/CD failing in their fork.