### PR TITLE
chore: sync labels

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -18,6 +18,8 @@ jobs:
             cowprotocol/pm
             cowprotocol/composable-cow
             cowprotocol/composable-dao
+            cowprotocol/tenderly-watch-tower
             cowprotocol/clogs
+            cowprotocol/docs
           token: ${{ secrets.SYNC_LABELS }}
           prune: true


### PR DESCRIPTION
This PR:

1. Adds `tenderly-watch-tower` and `docs` to the label sync list.