### PR TITLE
Update sync action

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: micnncim/action-label-syncer@v1
+      - uses: brpaz/action-label-syncer@master
         with:
           manifest: .github/labels.yml
           repository: |


### PR DESCRIPTION
The action we use for syncing the lables across repos is unmaintained and seemingly stopped working. Unfortunately there are no error messages so it's not clear why my new lable does not get created.

Replaces the action with a forked version with updated dependencies and improved (or rather any) error reporting.