### PR TITLE
Add PR metrics action

### DIFF
--- a/.github/workflows/pull-request-analytics.yml
+++ b/.github/workflows/pull-request-analytics.yml
@@ -1,0 +1,27 @@
+name: "PR Analytics"
+on:
+  workflow_dispatch:
+    inputs:
+      report_date_start:
+        description: "Report date start (d/MM/yyyy)"
+      report_date_end:
+        description: "Report date end (d/MM/yyyy)"
+jobs:
+  create-report:
+    name: "Create report"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Run script for analytics"
+        uses: AlexSim93/pull-request-analytics-action@v4
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # In the case of a personal access token, it needs to be added to the repository's secrets and used in this field.
+          CORE_HOURS_START: "9:00"
+          CORE_HOURS_END: "19:00"
+          TIMEZONE: "Europe/Berlin"
+          REPORT_DATE_START: ${{ inputs.report_date_start }}
+          REPORT_DATE_END: ${{ inputs.report_date_end }}
+          USE_CHARTS: true
+          SHOW_CORRELATION_GRAPHS: true
+          SHOW_ACTIVITY_TIME_GRAPHS: true
+          GITHUB_OWNERS_REPOS: "cowprotocol/services, cowprotocol/infrastructure"
+          EXECUTION_OUTCOME: "markdown"

--- a/.github/workflows/pull-request-analytics.yml
+++ b/.github/workflows/pull-request-analytics.yml
@@ -17,7 +17,7 @@ jobs:
       - name: "Run script for analytics"
         uses: AlexSim93/pull-request-analytics-action@v4
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # In the case of a personal access token, it needs to be added to the repository's secrets and used in this field.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPO_FOR_ISSUE: pm
           GITHUB_OWNER_FOR_ISSUE: cowprotocol
           GITHUB_OWNERS_REPOS: ${{ inputs.repository }}

--- a/.github/workflows/pull-request-analytics.yml
+++ b/.github/workflows/pull-request-analytics.yml
@@ -28,4 +28,6 @@ jobs:
           USE_CHARTS: true
           SHOW_CORRELATION_GRAPHS: true
           SHOW_ACTIVITY_TIME_GRAPHS: true
-          EXECUTION_OUTCOME: "markdown"
+          EXECUTION_OUTCOME: "markdown, new-issue"
+          REPORT_DATE_START: 01/01/2024
+          REPORT_DATE_END: 01/12/2024

--- a/.github/workflows/pull-request-analytics.yml
+++ b/.github/workflows/pull-request-analytics.yml
@@ -23,8 +23,8 @@ jobs:
           CORE_HOURS_START: "9:00"
           CORE_HOURS_END: "19:00"
           TIMEZONE: "Europe/Berlin"
-          REPORT_DATE_START: ${{ inputs.report_date_start }}
-          REPORT_DATE_END: ${{ inputs.report_date_end }}
+          # REPORT_DATE_START: ${{ inputs.report_date_start }}
+          # REPORT_DATE_END: ${{ inputs.report_date_end }}
           USE_CHARTS: true
           SHOW_CORRELATION_GRAPHS: true
           SHOW_ACTIVITY_TIME_GRAPHS: true

--- a/.github/workflows/pull-request-analytics.yml
+++ b/.github/workflows/pull-request-analytics.yml
@@ -1,5 +1,6 @@
 name: "PR Analytics"
 on:
+  pull_request:
   workflow_dispatch:
     inputs:
       report_date_start:

--- a/.github/workflows/pull-request-analytics.yml
+++ b/.github/workflows/pull-request-analytics.yml
@@ -16,6 +16,10 @@ jobs:
         uses: AlexSim93/pull-request-analytics-action@v4
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # In the case of a personal access token, it needs to be added to the repository's secrets and used in this field.
+          GITHUB_REPO_FOR_ISSUE: cowprotocol/pm
+          GITHUB_OWNER_FOR_ISSUE: cowprotocol
+          GITHUB_OWNERS_REPOS: "cowprotocol/services"
+
           CORE_HOURS_START: "9:00"
           CORE_HOURS_END: "19:00"
           TIMEZONE: "Europe/Berlin"
@@ -24,5 +28,4 @@ jobs:
           USE_CHARTS: true
           SHOW_CORRELATION_GRAPHS: true
           SHOW_ACTIVITY_TIME_GRAPHS: true
-          GITHUB_OWNERS_REPOS: "cowprotocol/services"
           EXECUTION_OUTCOME: "markdown"

--- a/.github/workflows/pull-request-analytics.yml
+++ b/.github/workflows/pull-request-analytics.yml
@@ -24,5 +24,5 @@ jobs:
           USE_CHARTS: true
           SHOW_CORRELATION_GRAPHS: true
           SHOW_ACTIVITY_TIME_GRAPHS: true
-          GITHUB_OWNERS_REPOS: "cowprotocol/services, cowprotocol/infrastructure"
+          GITHUB_OWNERS_REPOS: "cowprotocol/services"
           EXECUTION_OUTCOME: "markdown"

--- a/.github/workflows/pull-request-analytics.yml
+++ b/.github/workflows/pull-request-analytics.yml
@@ -1,12 +1,14 @@
 name: "PR Analytics"
 on:
-  pull_request:
   workflow_dispatch:
     inputs:
       report_date_start:
         description: "Report date start (d/MM/yyyy)"
       report_date_end:
         description: "Report date end (d/MM/yyyy)"
+      repository:
+        description: "Repo to analyze (owner/repo)"
+        default: "cowprotocol/services"
 jobs:
   create-report:
     name: "Create report"
@@ -18,16 +20,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # In the case of a personal access token, it needs to be added to the repository's secrets and used in this field.
           GITHUB_REPO_FOR_ISSUE: pm
           GITHUB_OWNER_FOR_ISSUE: cowprotocol
-          GITHUB_OWNERS_REPOS: "cowprotocol/services"
-
+          GITHUB_OWNERS_REPOS: ${{ inputs.repository }}
+          REPORT_DATE_START: ${{ inputs.report_date_start }}
+          REPORT_DATE_END: ${{ inputs.report_date_end }}
           CORE_HOURS_START: "9:00"
           CORE_HOURS_END: "19:00"
           TIMEZONE: "Europe/Berlin"
-          # REPORT_DATE_START: ${{ inputs.report_date_start }}
-          # REPORT_DATE_END: ${{ inputs.report_date_end }}
           USE_CHARTS: true
           SHOW_CORRELATION_GRAPHS: true
           SHOW_ACTIVITY_TIME_GRAPHS: true
-          EXECUTION_OUTCOME: "markdown, new-issue"
-          REPORT_DATE_START: 01/10/2024
-          REPORT_DATE_END: 01/11/2024
+          EXECUTION_OUTCOME: "new-issue"

--- a/.github/workflows/pull-request-analytics.yml
+++ b/.github/workflows/pull-request-analytics.yml
@@ -29,5 +29,5 @@ jobs:
           SHOW_CORRELATION_GRAPHS: true
           SHOW_ACTIVITY_TIME_GRAPHS: true
           EXECUTION_OUTCOME: "markdown, new-issue"
-          REPORT_DATE_START: 01/01/2024
-          REPORT_DATE_END: 01/12/2024
+          REPORT_DATE_START: 01/10/2024
+          REPORT_DATE_END: 01/11/2024

--- a/.github/workflows/pull-request-analytics.yml
+++ b/.github/workflows/pull-request-analytics.yml
@@ -16,7 +16,7 @@ jobs:
         uses: AlexSim93/pull-request-analytics-action@v4
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # In the case of a personal access token, it needs to be added to the repository's secrets and used in this field.
-          GITHUB_REPO_FOR_ISSUE: cowprotocol/pm
+          GITHUB_REPO_FOR_ISSUE: pm
           GITHUB_OWNER_FOR_ISSUE: cowprotocol
           GITHUB_OWNERS_REPOS: "cowprotocol/services"
 


### PR DESCRIPTION
Adds [action](https://github.com/AlexSim93/pull-request-analytics-action) to generate report on various metrics related to code reviews.
This should give us valuable information to help us improve the code review culture.
This PR only enables it for the services and infra repo.

Tested with hardcoded values until the action successfully created this [report](https://github.com/cowprotocol/pm/issues/86).
Afterwards I made the replaced the hard coded start-date, end-date and target repo with inputs in the manually triggerable action. (becomes available after merging this PR).